### PR TITLE
result positioning fix, layout updates for multi-column results, prettier formatting

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -120,10 +120,6 @@
       margin: 0 5px 5px 5px;
     }
 
-    .badge-wrapper {
-      min-width: 0;
-    }
-
     .heading {
       padding: 5px 0 5px 5px;
 

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -3,10 +3,11 @@
 }
 
 .d-header .header-buttons {
-  margin-top: .1em;
+  margin-top: 0.1em;
 }
 
-.header-search-enabled .search-header a, .header-search-enabled .search-header a:visited {
+.header-search-enabled .search-header a,
+.header-search-enabled .search-header a:visited {
   color: $tertiary;
 }
 
@@ -15,40 +16,42 @@
 }
 
 .header-search-enabled.align-right .contents {
-   display: flex;
-   justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 
-   &:before, &:after {
-     display: none;
-   }
+  &:before,
+  &:after {
+    display: none;
+  }
 
-   .title {
-     flex: 1 1 auto;
-     justify-content: space-between;
-   }
+  .title {
+    flex: 1 1 auto;
+    justify-content: space-between;
+  }
 
-   .search-header {
-     align-self: flex-start;
-     margin: 15px 0 0 10px;
-   }
+  .search-header {
+    align-self: flex-start;
+    margin: 15px 0 0 10px;
+  }
 
-   .search-input {
-     margin-right: 0;
-   }
+  .search-input {
+    margin-right: 0;
+  }
 
-   .search-context {
-     padding-top: 5px;
-   }
+  .search-context {
+    padding-top: 5px;
+  }
 
-   .results {
-     right: 0;
-   }
+  .results {
+    right: 0;
+  }
 }
 
 .title .search-header {
   width: 350px;
   margin-left: 20px;
-  margin-top: 4px;
+  margin-top: 14px;
+  align-self: flex-start;
   position: relative;
   white-space: nowrap;
 
@@ -84,7 +87,7 @@
     padding: 5px;
 
     label {
-        float: left;
+      float: left;
     }
   }
 
@@ -93,9 +96,32 @@
     width: 100%;
     white-space: normal;
 
+    .main-results {
+      min-width: 0;
+      .search-result-topic {
+        width: 100%;
+        .topic {
+          max-width: 100%;
+        }
+        .badge-wrapper {
+          min-width: 0;
+        }
+      }
+    }
+
+    .secondary-results {
+      .badge-wrapper {
+        width: 100%;
+      }
+    }
+
     ul {
       list-style-type: none;
       margin: 0 5px 5px 5px;
+    }
+
+    .badge-wrapper {
+      min-width: 0;
     }
 
     .heading {
@@ -122,7 +148,10 @@
       .topic-statuses {
         float: none;
         display: inline-block;
-        color: dark-light-choose(scale-color($primary, $lightness: 50%), scale-color($secondary, $lightness: 50%));
+        color: dark-light-choose(
+          scale-color($primary, $lightness: 50%),
+          scale-color($secondary, $lightness: 50%)
+        );
         margin: 0;
         .fa {
           margin: 0;
@@ -141,7 +170,7 @@
       a {
         display: block;
         padding: 5px;
-        transition: all linear .15s;
+        transition: all linear 0.15s;
       }
 
       &:hover a:not(.badge-notification) {


### PR DESCRIPTION
Some fixes to get this back into action. The added CSS to pay attention to is on lines 54 & 99-117. The rest is standard https://prettier.io/ formatting.

<img width="387" alt="Screen Shot 2019-10-21 at 10 19 29 PM" src="https://user-images.githubusercontent.com/1681963/67255619-fb2b7100-f450-11e9-97de-4a9314a365f9.png">
