### PR TITLE
FIX: deprecations for ember-cli

### DIFF
--- a/desktop/head_tag.html
+++ b/desktop/head_tag.html
@@ -1,6 +1,7 @@
 <script type="text/discourse-plugin" version='0.8.13'>
 
 api.modifyClass('component:site-header', {
+  pluginId: "discourse-header-search-theme",
   toggleVisibility: function(topicToggled) {
     const headerWidth = this.$('.d-header .contents').width();
     const panelWidth = this.$('.d-header .panel').width();
@@ -74,7 +75,7 @@ api.reopenWidget('search-menu', {
       classes.push('show-header-results');
     }
 
-    const service = this.register.lookup("search-service:main");
+    const service = this.register.lookup("service:search");
     const ctx = service.get("searchContext");
     if (ctx) {
       classes.push('has-context');


### PR DESCRIPTION
I copy-pasted these into my browser on github. I have not tested these, but I think they're right? 

```
Deprecation notice: "search-service:main" is deprecated, use "service:search" instead (deprecated since Discourse 2.8.0.beta8) (removal in Discourse 2.9.0.beta1)

To prevent errors in tests, add a `pluginId` key to your `modifyClass` call. This will ensure the modification is only applied once.
```