### PR TITLE
Set maximum_discourse_version and add end-of-life info

### DIFF
--- a/about.json
+++ b/about.json
@@ -2,5 +2,6 @@
   "name": "Header Search",
   "about_url": "https://meta.discourse.org/t/header-search-plugin/36435",
   "license_url": "https://github.com/angusmcleod/discourse-header-search/blob/master/LICENSE.txt",
-  "component": true
+  "component": true,
+  "maximum_discourse_version": "3.2.0.beta4"
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,3 @@
+en: 
+  theme_metadata:
+    description: This theme is no longer supported. See https://meta.discourse.org/t/67959/70


### PR DESCRIPTION
This will stop the theme component from causing catastrophic errors when installed on up-to-date Discourse sites.

<img width="794" alt="SCR-20240201-mfwt" src="https://github.com/paviliondev/discourse-header-search-theme/assets/6270921/3b496e5b-5954-4427-aa44-1b7282eb8e9a">

`3.2.0.beta4` is the last version which shipped with Ember 3 by default.